### PR TITLE
MacOS support & documentations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build/*
 build-dir
 .flatpak-builder
 result
+aprilv0_en-us.april

--- a/README.md
+++ b/README.md
@@ -57,13 +57,38 @@ You can build this easily with GNOME Builder. After cloning, open the project di
 If you are using Flatpak GNOME Builder and experience issues running this (for example, some cryptic X Window System error), please try using your distro's native packaged version of GNOME Builder instead of Flatpak (e.g. `sudo apt install gnome-builder`).
 
 ## Option 2: Building from the terminal (not as easy)
-First you must [download ONNXRuntime v1.13.1](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz), extract it somewhere, and set the environment variables to point to it:
+First you must [download ONNXRuntime v1.13.1 (Linux)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz) or [ONNXRuntime v.1.13.1 (OSX)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-x86_64-1.13.1.tgz), extract it somewhere, and set the environment variables to point to it:
 ```
 $ export ONNX_ROOT=/path/to/onnxruntime-linux-x64-1.13.1/
+```
+
+Now, on Linux, do this:
+```
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/onnxruntime-linux-x64-1.13.1/lib
 ```
 
+or, on Mac:
+```
+$ cp /path/to/onnxruntime-osx-x86_64-1.13.1/lib/libonnxruntime.1.13.1.dylib /usr/local/lib/libonnxruntime.1.13.1.dylib
+$ cp /path/to/onnxruntime-osx-x86_64-1.13.1/lib/libonnxruntime.dylib /usr/local/lib/libonnxruntime.dylib
+```
+
 Alternatively you should also be able to locally build and install ONNXRuntime, in which case that step shouldn't be necessary.
+
+You will also need the following prerequisites:
+```
+pulseaudio
+libadwaita
+meson
+ninja
+```
+
+If you're on macOS, you may have to run the following command for Pulseaudio to be registered as a background service:
+```
+brew services restart pulseaudio
+```
+
+and to stop it, just change `restart` for stop.
 
 To set up a build, run these commands:
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Features:
 
 Running this requires a somewhat-decent CPU that can perform realtime captioning, especially if you want to be doing other tasks (such as video decode) while running Live Captions. It has been tested working on:
 * Intel i7-2670QM (2011)
+* Intel i7-7820HQ (2017)
 * Intel i5-8265U (2018)
 * AMD Ryzen 5 1600 (2017)
 * Steam Deck

--- a/README.md
+++ b/README.md
@@ -104,3 +104,5 @@ $ export APRIL_MODEL_PATH=`pwd`/aprilv0_en-us.april
 ```
 
 You should now be able to run the app with `src/livecaptions`
+
+If you're on MacOS, now, go to security settings and confirm the prompt which asks to allow `libonnxruntime`, then, the application should work as intended.

--- a/README.md
+++ b/README.md
@@ -57,18 +57,17 @@ You can build this easily with GNOME Builder. After cloning, open the project di
 If you are using Flatpak GNOME Builder and experience issues running this (for example, some cryptic X Window System error), please try using your distro's native packaged version of GNOME Builder instead of Flatpak (e.g. `sudo apt install gnome-builder`).
 
 ## Option 2: Building from the terminal (not as easy)
-First you must [download ONNXRuntime v1.13.1 (Linux)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz) or [ONNXRuntime v.1.13.1 (OSX)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-x86_64-1.13.1.tgz), extract it somewhere, and set the environment variables to point to it:
+First you must [download ONNXRuntime v1.13.1 (Linux)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz) or [ONNXRuntime v.1.13.1 (OSX)](https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-x86_64-1.13.1.tgz), extract it somewhere, and set the environment variables to point to it.
+
+Linux:
 ```
 $ export ONNX_ROOT=/path/to/onnxruntime-linux-x64-1.13.1/
-```
-
-Now, on Linux, do this:
-```
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/onnxruntime-linux-x64-1.13.1/lib
 ```
 
 or, on Mac:
 ```
+$ export ONNX_ROOT=/path/to/onnxruntime-osx-x86_64-1.13.1/
 $ cp /path/to/onnxruntime-osx-x86_64-1.13.1/lib/libonnxruntime.1.13.1.dylib /usr/local/lib/libonnxruntime.1.13.1.dylib
 $ cp /path/to/onnxruntime-osx-x86_64-1.13.1/lib/libonnxruntime.dylib /usr/local/lib/libonnxruntime.dylib
 ```

--- a/meson.build
+++ b/meson.build
@@ -36,5 +36,5 @@ subdir('po')
 gnome.post_install(
   glib_compile_schemas: true,
   gtk_update_icon_cache: true,
-  update_desktop_database: true,
+  update_desktop_database: false,
 )

--- a/src/history.c
+++ b/src/history.c
@@ -51,8 +51,8 @@ void history_init(void){
 
 static struct history_entry *allocate_new_entry(size_t tokens_count) {
     active_session.entries_count += 1;
-    active_session.entries = reallocarray(active_session.entries,
-        active_session.entries_count, sizeof(struct history_entry));
+    active_session.entries = realloc(active_session.entries,
+        active_session.entries_count * sizeof(struct history_entry));
 
     struct history_entry *entry = &active_session.entries[active_session.entries_count - 1];
 

--- a/src/livecaptions-history-window.c
+++ b/src/livecaptions-history-window.c
@@ -127,6 +127,7 @@ static void add_session(LiveCaptionsHistoryWindow *self, const struct history_se
 
     FilterMode filter_mode = filter_profanity ? FILTER_PROFANITY : (filter_slurs ? FILTER_SLURS : FILTER_NONE);
     struct token_capitalizer tcap;
+    extern void token_capitalizer_init(struct token_capitalizer *tc);
     token_capitalizer_init(&tcap);
 
     for(size_t i_1=0; i_1<session->entries_count; i_1++){


### PR DESCRIPTION
This requires the april-asr pull request I opened which catches macOS in preprocessor to be merged.

Here's a video of this in action

https://github.com/abb128/LiveCaptions/assets/51248378/b460ea9c-f47a-4275-9b0b-3b1464a4fd1a

I am willing to help with updating other documentation or README and such to update the presentation to cover MacOS, so please point me somewhere that you'd want me to look and update.