### PR TITLE
build(nix): add macOS derivation, use april-asr flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,17 @@
         "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
       },
       "locked": {
-        "lastModified": 1683923676,
-        "narHash": "sha256-i5zzSdTHFAPJ7sE8A54KKM5DiyFkfcth8BrBvcxZK/Q=",
+        "lastModified": 1683928804,
+        "narHash": "sha256-BoWlEmUlJ7svOdGzd9dOSrKM5AbEF8BzgqMR01s6B4c=",
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "d032c6eebbff960febff50f4c56d1e1420b1b318",
+        "rev": "7baa7b6bff823e7f3672813922ae141b7b5d6d1d",
         "type": "github"
       },
       "original": {
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "d032c6eebbff960febff50f4c56d1e1420b1b318",
+        "rev": "7baa7b6bff823e7f3672813922ae141b7b5d6d1d",
         "type": "github"
       }
     },
@@ -101,22 +101,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-onnxruntime114_2": {
-      "locked": {
-        "lastModified": 1682978478,
-        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1683014792,
@@ -138,8 +122,7 @@
         "april-asr": "april-asr",
         "april-asr-model": "april-asr-model",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114_2"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,17 @@
         "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
       },
       "locked": {
-        "lastModified": 1683928804,
-        "narHash": "sha256-BoWlEmUlJ7svOdGzd9dOSrKM5AbEF8BzgqMR01s6B4c=",
+        "lastModified": 1683931363,
+        "narHash": "sha256-2USL/D4OtW8HBdM3Okz1zN2k+ZD6Cq9NBbIFrbDwKSk=",
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "7baa7b6bff823e7f3672813922ae141b7b5d6d1d",
+        "rev": "9979ff5065f85c6b603f04c3579ace24ab32db8d",
         "type": "github"
       },
       "original": {
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "7baa7b6bff823e7f3672813922ae141b7b5d6d1d",
+        "rev": "9979ff5065f85c6b603f04c3579ace24ab32db8d",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -3,20 +3,20 @@
     "april-asr": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
       },
       "locked": {
-        "lastModified": 1684033667,
-        "narHash": "sha256-XtGLLK9i6pIMcmOmM1XI3/i9EQr7qaHIPlzOaXfgEPE=",
-        "owner": "nekowinston",
+        "lastModified": 1684333041,
+        "narHash": "sha256-2USL/D4OtW8HBdM3Okz1zN2k+ZD6Cq9NBbIFrbDwKSk=",
+        "owner": "abb128",
         "repo": "april-asr",
-        "rev": "496d052752bb4f47675a74a034aaf4a237d4fb76",
+        "rev": "1bb428922db7e4ce50fcdea0d16eb4429a2d2e9d",
         "type": "github"
       },
       "original": {
-        "owner": "nekowinston",
+        "owner": "abb128",
         "repo": "april-asr",
-        "rev": "496d052752bb4f47675a74a034aaf4a237d4fb76",
         "type": "github"
       }
     },
@@ -81,6 +81,22 @@
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-onnxruntime114": {
+      "locked": {
+        "lastModified": 1682978478,
+        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,36 @@
 {
   "nodes": {
     "april-asr": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
+      },
+      "locked": {
+        "lastModified": 1683923676,
+        "narHash": "sha256-i5zzSdTHFAPJ7sE8A54KKM5DiyFkfcth8BrBvcxZK/Q=",
+        "owner": "nekowinston",
+        "repo": "april-asr",
+        "rev": "d032c6eebbff960febff50f4c56d1e1420b1b318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nekowinston",
+        "repo": "april-asr",
+        "rev": "d032c6eebbff960febff50f4c56d1e1420b1b318",
+        "type": "github"
+      }
+    },
+    "april-asr-model": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-lnFZ7RYdN9cZ7FEbwaSsgqJyVxY1sf0pWxCa43lsGv8=",
+        "narHash": "sha256-o68Ivb9Iyy71pu6qnxc04x6aDmVu1ql2Mq1NJE7sZRE=",
         "type": "file",
-        "url": "https://april.sapples.net/aprilv0_en-us.april"
+        "url": "https://april.sapples.net/april-english-dev-01110_en.april"
       },
       "original": {
         "type": "file",
-        "url": "https://april.sapples.net/aprilv0_en-us.april"
+        "url": "https://april.sapples.net/april-english-dev-01110_en.april"
       }
     },
     "flake-utils": {
@@ -30,7 +51,73 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-onnxruntime114": {
+      "locked": {
+        "lastModified": 1682978478,
+        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-onnxruntime114_2": {
+      "locked": {
+        "lastModified": 1682978478,
+        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1683014792,
         "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
@@ -49,11 +136,28 @@
     "root": {
       "inputs": {
         "april-asr": "april-asr",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "april-asr-model": "april-asr-model",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,21 +3,20 @@
     "april-asr": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1683931363,
-        "narHash": "sha256-2USL/D4OtW8HBdM3Okz1zN2k+ZD6Cq9NBbIFrbDwKSk=",
+        "lastModified": 1684033667,
+        "narHash": "sha256-XtGLLK9i6pIMcmOmM1XI3/i9EQr7qaHIPlzOaXfgEPE=",
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "9979ff5065f85c6b603f04c3579ace24ab32db8d",
+        "rev": "496d052752bb4f47675a74a034aaf4a237d4fb76",
         "type": "github"
       },
       "original": {
         "owner": "nekowinston",
         "repo": "april-asr",
-        "rev": "9979ff5065f85c6b603f04c3579ace24ab32db8d",
+        "rev": "496d052752bb4f47675a74a034aaf4a237d4fb76",
         "type": "github"
       }
     },
@@ -82,22 +81,6 @@
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-onnxruntime114": {
-      "locked": {
-        "lastModified": 1682978478,
-        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-onnxruntime114.url = "github:nixos/nixpkgs/c7d48290f9da479dcab26eac5db6299739c595c2";
-    # TODO: replace with upstreamed version on abb128
-    april-asr.url = "github:nekowinston/april-asr/d032c6eebbff960febff50f4c56d1e1420b1b318";
+    april-asr.url = "github:nekowinston/april-asr/7baa7b6bff823e7f3672813922ae141b7b5d6d1d";
     april-asr-model = {
       url = "https://april.sapples.net/april-english-dev-01110_en.april";
       flake = false;
@@ -16,7 +14,6 @@
     april-asr,
     april-asr-model,
     nixpkgs,
-    nixpkgs-onnxruntime114,
     flake-utils,
   }:
     flake-utils.lib.eachDefaultSystem (
@@ -24,11 +21,9 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            # TODO: remove once https://github.com/NixOS/nixpkgs/pull/226734 is merged
             (
               final: prev: {
-                onnxruntime = nixpkgs-onnxruntime114.legacyPackages.${prev.system}.onnxruntime;
-                aprilasr = april-asr.packages.${prev.system}.april-asr;
+                aprilasr = april-asr.packages.${prev.system};
               }
             )
           ];
@@ -55,8 +50,8 @@
               glib # glib-compile-schemas
               libadwaita # libadwaita-1
               libpulseaudio # libpulse
-              onnxruntime
-              aprilasr
+              aprilasr.april-asr
+              aprilasr.onnxruntime_1_14
             ];
             patchPhase = ''
               # remove lines containing april

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    april-asr.url = "github:nekowinston/april-asr/9979ff5065f85c6b603f04c3579ace24ab32db8d";
+    april-asr.url = "github:nekowinston/april-asr/496d052752bb4f47675a74a034aaf4a237d4fb76";
     april-asr-model = {
       url = "https://april.sapples.net/april-english-dev-01110_en.april";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -3,26 +3,45 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    april-asr = {
-      url = "https://april.sapples.net/aprilv0_en-us.april";
+    nixpkgs-onnxruntime114.url = "github:nixos/nixpkgs/c7d48290f9da479dcab26eac5db6299739c595c2";
+    # TODO: replace with upstreamed version on abb128
+    april-asr.url = "github:nekowinston/april-asr/d032c6eebbff960febff50f4c56d1e1420b1b318";
+    april-asr-model = {
+      url = "https://april.sapples.net/april-english-dev-01110_en.april";
       flake = false;
     };
   };
   outputs = {
     self,
     april-asr,
+    april-asr-model,
     nixpkgs,
+    nixpkgs-onnxruntime114,
     flake-utils,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # TODO: remove once https://github.com/NixOS/nixpkgs/pull/226734 is merged
+            (
+              final: prev: {
+                onnxruntime = nixpkgs-onnxruntime114.legacyPackages.${prev.system}.onnxruntime;
+                aprilasr = april-asr.packages.${prev.system}.april-asr;
+              }
+            )
+          ];
+        };
+        inherit (pkgs) lib;
+        inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
       in {
         packages = rec {
-          livecaptions = pkgs.stdenv.mkDerivation rec {
+          livecaptions = pkgs.stdenv.mkDerivation {
             src = ./.;
             name = "livecaptions";
             nativeBuildInputs = with pkgs; [
+              makeWrapper
               meson
               ninja
               wrapGAppsHook
@@ -37,15 +56,24 @@
               libadwaita # libadwaita-1
               libpulseaudio # libpulse
               onnxruntime
+              aprilasr
             ];
-            preFixup = ''
-              gappsWrapperArgs+=(--prefix APRIL_MODEL_PATH : "${april-asr}")
+            patchPhase = ''
+              # remove lines containing april
+              sed -i "/april/d" meson.build
+              sed -i "s/april_lib/dependency('aprilasr')/" src/meson.build
             '';
-            meta = with pkgs.lib; {
+            preFixup =
+              lib.optionalString isLinux ''
+                gappsWrapperArgs+=(--prefix APRIL_MODEL_PATH : "${april-asr-model}")
+              ''
+              + lib.optionalString isDarwin ''
+                wrapProgram "$out/bin/livecaptions" --prefix APRIL_MODEL_PATH : "${april-asr-model}"
+              '';
+            meta = with lib; {
               description = "Linux Desktop application that provides live captioning";
               homepage = "https://github.com/abb128/LiveCaptions";
               license = licenses.gpl3;
-              platforms = platforms.linux;
             };
           };
           default = livecaptions;
@@ -58,7 +86,7 @@
           inherit (self.packages.${system}.livecaptions) buildInputs nativeBuildInputs;
           shellHook = ''
             export LD_LIBRARY_PATH=${pkgs.onnxruntime}/lib
-            export APRIL_MODEL_PATH=${april-asr}
+            export APRIL_MODEL_PATH=${april-asr-model}
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    april-asr.url = "github:nekowinston/april-asr/7baa7b6bff823e7f3672813922ae141b7b5d6d1d";
+    april-asr.url = "github:nekowinston/april-asr/9979ff5065f85c6b603f04c3579ace24ab32db8d";
     april-asr-model = {
       url = "https://april.sapples.net/april-english-dev-01110_en.april";
       flake = false;
@@ -18,16 +18,7 @@
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            (
-              final: prev: {
-                aprilasr = april-asr.packages.${prev.system};
-              }
-            )
-          ];
-        };
+        pkgs = import nixpkgs {inherit system;};
         inherit (pkgs) lib;
         inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
       in {
@@ -39,22 +30,19 @@
               makeWrapper
               meson
               ninja
+              pkg-config
               wrapGAppsHook
             ];
             buildInputs = with pkgs; [
-              cmake
-              pkgconfig
               appstream-glib # appstream-util
+              april-asr.packages.${system}.april-asr # april-asr
               desktop-file-utils # desktop-file-utils
               gettext # msgfmt
               glib # glib-compile-schemas
               libadwaita # libadwaita-1
               libpulseaudio # libpulse
-              aprilasr.april-asr
-              aprilasr.onnxruntime_1_14
             ];
             patchPhase = ''
-              # remove lines containing april
               sed -i "/april/d" meson.build
               sed -i "s/april_lib/dependency('aprilasr')/" src/meson.build
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    april-asr.url = "github:nekowinston/april-asr/496d052752bb4f47675a74a034aaf4a237d4fb76";
+    april-asr.url = "github:abb128/april-asr";
     april-asr-model = {
       url = "https://april.sapples.net/april-english-dev-01110_en.april";
       flake = false;


### PR DESCRIPTION
Hi, this is the followup PR for abb128/april-asr#9.

I've added support to macOS and tested it on my M1, a Fedora arm64 system, and Pop!OS x86_64 system.

I'll change the `inputs.april-asr.url` to your repository once it's merged over there.