### PR TITLE
Remove `use-size`

### DIFF
--- a/src/livecaptions-settings.ui
+++ b/src/livecaptions-settings.ui
@@ -56,7 +56,6 @@
                   <object class="GtkFontButton" id="font_button">
                     <property name="valign">center</property>
                     <property name="use-font">True</property>
-                    <property name="use-size">True</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
This makes the font button massive depending on the font size. It's best to keep the size so that it doesn't mess up the UI.